### PR TITLE
Suppression de la combinatoire générée par les suites de siret.

### DIFF
--- a/histo_sirene.sh
+++ b/histo_sirene.sh
@@ -11,7 +11,18 @@
 # dépendances: csvkit, unzip (sudo apt install csvkit unzip)
 
 unzip -p $1|iconv -f cp1252 -t $(locale charmap) |
-csvcut -c SIREN,DATEMAJ,NIC,SIRETPS,NICSIEGE,VMAJ,EVE -d ';' -v| \
-egrep '(^SIREN|,(CTE|CTS|MTDE|MTAE|MTDS|MTAS|STE|STS|SU)$)' | \
-csvsql --query "select o.siren||substr('0000' || o.nic, -5, 5) as SIRET_OLD, n.siren||substr('0000' || n.nic, -5, 5) as SIRET_NEW, o.datemaj from stdin o join stdin n on (o.siren=n.siren and o.datemaj=n.datemaj and o.nic<n.nic) union select siren||substr('0000' || nic, -5, 5) as SIRET_NEW, siretps, datemaj from stdin where siretps <> '' and cast(siren as text) <> substr(siretps, 0, 10);" > ${1/.zip}-histo.csv
+csvcut -c SIREN,DATEMAJ,NIC,SIRETPS,NICSIEGE,VMAJ,EVE -d ';' -v|
+egrep '(^SIREN|,(CTE|CTS|MTDE|MTAE|MTDS|MTAS|STE|STS|SU)$)' |
+csvsql --query "select o.siren||substr('0000' || o.nic, -5, 5) as SIRET_OLD, \
+                       n.siren||substr('0000' || n.nic, -5, 5) as SIRET_NEW, \
+                       o.datemaj \
+                    from stdin o \
+                    join stdin n on (o.siren=n.siren and o.datemaj=n.datemaj and o.nic<n.nic) \
+                    left join stdin f on f.siren=n.siren and f.datemaj=n.datemaj and f.nic < n.nic and f.nic > o.nic \
+                    where f.siren is null \
+                  union \
+                select siren||substr('0000' || nic, -5, 5) as SIRET_NEW, \
+                             siretps, datemaj \
+                    from stdin \
+                    where siretps <> '' and cast(siren as text) <> substr(siretps, 0, 10);" > ${1/.zip}-histo.csv
 

--- a/histo_sirene.sh
+++ b/histo_sirene.sh
@@ -10,9 +10,9 @@
 
 # dépendances: csvkit, unzip (sudo apt install csvkit unzip)
 
-unzip -p $1|iconv -f cp1252 -t $(locale charmap) |
-csvcut -c SIREN,DATEMAJ,NIC,SIRETPS,NICSIEGE,VMAJ,EVE -d ';' -v|
-egrep '(^SIREN|,(CTE|CTS|MTDE|MTAE|MTDS|MTAS|STE|STS|SU)$)' |
+unzip -p $1|iconv -f cp1252 -t utf8 |
+csvcut -c SIREN,DATEMAJ,NIC,SIRETPS,NICSIEGE,VMAJ,EVE -d ';' -v| \
+egrep '(^SIREN|,(CTE|CTS|MTDE|MTAE|MTDS|MTAS|STE|STS|SU)$)' | \
 csvsql --query "select o.siren||substr('0000' || o.nic, -5, 5) as SIRET_OLD, \
                        n.siren||substr('0000' || n.nic, -5, 5) as SIRET_NEW, \
                        o.datemaj \

--- a/histo_sirene.sh
+++ b/histo_sirene.sh
@@ -25,6 +25,6 @@ csvsql --query "select o.siren||substr('0000' || o.nic, -5, 5) as SIRET_OLD, \
                        siren||substr('0000' || nic, -5, 5) as siret_new, \
                        datemaj \
                     from stdin \
-                    where siretps <> '' and cast(siren as text) <> substr(siretps, 0, 10)
+                    where siretps <> '' and cast(siren as text) <> substr(siretps, 0, 10) \
                     order by datemaj, siret_new, siret_old;" > ${1/.zip}-histo.csv
 

--- a/histo_sirene.sh
+++ b/histo_sirene.sh
@@ -10,7 +10,7 @@
 
 # dépendances: csvkit, unzip (sudo apt install csvkit unzip)
 
-unzip -p $1|iconv -f cp1252 -t utf8 |
+unzip -p $1 | iconv -f cp1252 -t utf8 |
 csvcut -c SIREN,DATEMAJ,NIC,SIRETPS,NICSIEGE,VMAJ,EVE -d ';' -v| \
 egrep '(^SIREN|,(CTE|CTS|MTDE|MTAE|MTDS|MTAS|STE|STS|SU)$)' | \
 csvsql --query "select o.siren||substr('0000' || o.nic, -5, 5) as SIRET_OLD, \


### PR DESCRIPTION
Il existe des cas où il semble y avoir plusieurs changement successifs de siret à la même date. Dans l'hypothèse où nous avons une suite de 4 siret, la requête va produire de résultat suivant:

siret1   siret2
siret1   siret3      <--- ligne inutile (voire fausse)
siret1   siret4      <--- ligne à supprimer également
siret2   siret3
siret2   siret4      <--- ligne à supprimer encore
siret3   siret4

Le patch proposé réalise cette opération en filtrant les lignes pour lesquels ont été trouvé 1 ou plusieurs sirets intermédiaires. Cela devrait faire fondre un peu la taille des résultats.

Par ailleurs j'ai remis le format readable sql… je peux également le remettre en one-line sql si besoin. 
Je me suis aussi permis de supprimer le group by, selon toute vraisemblance union fait déjà le travail de dédup.

ps: j'ai pas été des plus efficaces en réintégrant les commits d'avant, j'ai l'impression de ne pas avoir généré de déchet, mais au cas où, j'attends ici :)